### PR TITLE
Add support for building SLES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,24 @@ TOPDIR = /tmp/zookeeper-rpm
 PWD = $(shell pwd)
 URL = $(shell curl -s https://www.apache.org/dyn/closer.cgi/zookeeper/zookeeper-$(VERSION)/zookeeper-$(VERSION).tar.gz?asjson=1 | python -c 'import sys,json; data=json.load(sys.stdin); print data["preferred"] + data["path_info"]')
 
-rpm: $(SOURCE)
-	@rpmbuild -v -bb \
+rhel: $(SOURCE)
+	@DISTRIBUTION=el7 \
+	 REQUIRES_PRE_POST="chkconfig initscripts" \
+	 rpmbuild -v -bb \
 			--define "_sourcedir $(PWD)" \
 			--define "_rpmdir $(PWD)" \
-			--define "_topdir $(TOPDIR)" \
+			--define "_topdir $(TOPDIR)-el7" \
+			--define "version $(VERSION)" \
+			--define "build_number $(BUILD_NUMBER)" \
+			zookeeper.spec
+
+sles: $(SOURCE)
+	@DISTRIBUTION=sles \
+	 REQUIRES_PRE_POST="aaa_base" \
+	 rpmbuild -v -bb \
+			--define "_sourcedir $(PWD)" \
+			--define "_rpmdir $(PWD)" \
+			--define "_topdir $(TOPDIR)-sles" \
 			--define "version $(VERSION)" \
 			--define "build_number $(BUILD_NUMBER)" \
 			zookeeper.spec

--- a/README.md
+++ b/README.md
@@ -1,25 +1,34 @@
 zookeeper-redhat7-rpm
 ---------
 
-A set of scripts to package zookeeper for EL.
-Requires CentOS/RedHat 7.
+A set of scripts to package zookeeper for EL and SLES.
+Requires CentOS/RedHat 7/SLES 12.
 
 Setup
 -----
-Install build dependencies:
+Install build dependencies on RedHat:
 
     sudo yum install -y make rpmdevtools wget python-devel gcc autoconf automake libtool cppunit-devel
 
+Install build dependencies on SLES:
+
+    sudo zypper install -y make rpmdevtools wget python-devel gcc autoconf automake libtool cppunit-devel
+
 Building
 --------
+To build RedHat packages:
 
-    make rpm
+    make rhel
+
+To build SLES packages:
+
+    make sles
 
 Resulting RPMs will be avaliable at $(shell pwd)/x86_64
 
 Installing and operating
 ------------------------
-    sudo yum install zookeeper*.rpm
+    sudo {yum, zypper} install zookeeper*.rpm
     sudo systemctl start zookeeper
     sudo systemctl enable zookeeper
 

--- a/zookeeper.init
+++ b/zookeeper.init
@@ -16,9 +16,6 @@
 # Short-Description: Enable zookeeper  Server
 ### END INIT INFO
 
-# Source function library.
-. /etc/rc.d/init.d/functions
-
 prog="zookeeper"
 desc="zookeeper Server"
 
@@ -26,50 +23,12 @@ desc="zookeeper Server"
 
 lockfile="/var/lock/subsys/$prog"
 pidfile="/var/run/$prog.pid"
-
-[ "x$JMXLOCALONLY" = "x" ] && JMXLOCALONLY=false
-
-if [ "x$JMXDISABLE" = "x" ]
-then
-    # for some reason these two options are necessary on jdk6 on Ubuntu
-    #   accord to the docs they are not necessary, but otw jconsole cannot
-    #   do a local attach
-    ZOOMAIN="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=$JMXLOCALONLY org.apache.zookeeper.server.quorum.QuorumPeerMain"
-else
-    ZOOMAIN="org.apache.zookeeper.server.quorum.QuorumPeerMain"
-fi
-
-ZOOBINDIR="/usr/lib/zookeeper/bin"
-ZOOCFGDIR="/etc/zookeeper"
-ZOOCFG="zoo.cfg"
-ZOOCFG="$ZOOCFGDIR/$ZOOCFG"
-ZOO_LOG_DIR="/var/log/zookeeper"
-
-[ -e "$ZOOCFGDIR/java.env" ] && . "$ZOOCFGDIR/java.env"
-
-[ "x$ZOO_LOG4J_PROP" = "x" ] && ZOO_LOG4J_PROP="INFO,CONSOLE"
-
-for f in ${ZOOBINDIR}/../zookeeper-*.jar
-do 
-    CLASSPATH="$CLASSPATH:$f"
-done
-
-ZOOLIBDIR=${ZOOLIBDIR:-$ZOOBINDIR/../lib}
-for i in "$ZOOLIBDIR"/*.jar
-do
-    CLASSPATH="$CLASSPATH:$i"
-done
-
-#add the zoocfg dir to classpath
-CLASSPATH=$ZOOCFGDIR:$CLASSPATH
-
-cmd="java  \"-Dzookeeper.log.dir=${ZOO_LOG_DIR}\" \"-Dzookeeper.root.logger=${ZOO_LOG4J_PROP}\" -cp ${CLASSPATH} ${JVMFLAGS} ${ZOOMAIN} ${ZOOCFG} & echo \$! > ${pidfile}"
-
+export ZOOCFGDIR="/etc/zookeeper"
+. /usr/lib/zookeeper/bin/zkEnv.sh
 
 start() {
     echo -n $"Starting $desc ($prog): "
-    touch $pidfile && chown zookeeper $pidfile
-    daemon --user zookeeper --pidfile $pidfile "$cmd"
+    /usr/lib/zookeeper/bin/zkServer.sh start
     retval=$?
     echo
     [ $retval -eq 0 ] && touch $lockfile
@@ -78,7 +37,7 @@ start() {
 
 stop() {
     echo -n $"Stopping $prog: "
-    killproc -p $pidfile  $prog
+    /usr/lib/zookeeper/bin/zkServer.sh stop
     retval=$?
     echo
     [ $retval -eq 0 ] && rm -f $lockfile
@@ -95,15 +54,10 @@ reload() {
 }
 
 get_status() {
-    status $prog
-    RETVAL=$?
-    STAT=`echo stat | nc localhost $(grep clientPort $ZOOCFG | sed -e 's/.*=//') 2> /dev/null| grep Mode`
-    if [ "x$STAT" = "x" ]
-    then
-        echo "Error contacting service."
-    else
-        echo $STAT
-    fi
+    echo -n $"Status of $prog: "
+    /usr/lib/zookeeper/bin/zkServer.sh status
+    retval=$?
+    return retval
 }
 
 case "$1" in
@@ -119,7 +73,7 @@ case "$1" in
     reload)
         reload
         ;;
-    condrestart)
+    try-restart|condrestart)
         [ -e /var/lock/subsys/$prog ] && restart
         RETVAL=$?
         ;;
@@ -127,7 +81,7 @@ case "$1" in
         get_status
         ;;
     *)
-        echo $"Usage: $0 {start|stop|restart|reload|condrestart|status}"
+        echo $"Usage: $0 {start|stop|restart|reload|try-restart|condrestart|status}"
         RETVAL=1
 esac
 

--- a/zookeeper.spec
+++ b/zookeeper.spec
@@ -9,7 +9,7 @@
 Summary: High-performance coordination service for distributed applications.
 Name: zookeeper
 Version: %{rel_ver}
-Release: 1
+Release: 1.%{getenv:DISTRIBUTION}
 License: Apache License v2.0
 Group: Applications/Databases
 URL: http://hadoop.apache.org/zookeeper/
@@ -21,9 +21,9 @@ Source4: log4j.properties
 Source5: java.env
 BuildRoot: %{_tmppath}/%{name}-%{rel_ver}-%{release}-root
 BuildRequires: python-devel,gcc,autoconf,automake,libtool,cppunit-devel
-Requires: logrotate, java, cppunit
-Requires(post): chkconfig initscripts
-Requires(pre): chkconfig initscripts
+Requires: logrotate, java-headless
+Requires(post): %{getenv:REQUIRES_PRE_POST}
+Requires(pre): %{getenv:REQUIRES_PRE_POST}
 AutoReqProv: no
 
 %description


### PR DESCRIPTION
This patch adds support to build SLES 12 compatible rpm packages. To
simplify the maintenance, this patch also changes the zookeeper init
script to use the provided zkServer.sh init script, so the
start/stop/status init commands do not relay on specific distros.

Ref: MI-2157
Signed-off-by: Xavi León <xavi.leon@midokura.com>