### PR TITLE
Make el7 compatible with CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TOPDIR = /tmp/zookeeper-rpm
 PWD = $(shell pwd)
 URL = $(shell curl -s https://www.apache.org/dyn/closer.cgi/zookeeper/zookeeper-$(VERSION)/zookeeper-$(VERSION).tar.gz?asjson=1 | python -c 'import sys,json; data=json.load(sys.stdin); print data["preferred"] + data["path_info"]')
 
-rhel: $(SOURCE)
+rpm: $(SOURCE)
 	@DISTRIBUTION=el7 \
 	 REQUIRES_PRE_POST="chkconfig initscripts" \
 	 rpmbuild -v -bb \

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Building
 --------
 To build RedHat packages:
 
-    make rhel
+    make rpm
 
 To build SLES packages:
 


### PR DESCRIPTION
We use rpm for rhel platform packaging for historic reasons. Switch to
that label so we can reuse the existing jobs that use that use rpm as
platform for rhel.

Signed-off-by: Xavi León <xavi.leon@midokura.com>